### PR TITLE
Restrict torchmetrics version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ python_requires = >= 3.8
 install_requires =
     numpy
     torch
-    torchmetrics[detection]
+    torchmetrics[detection]==0.11.4
     opencv-python-headless
     Pillow>=6.2.2
 


### PR DESCRIPTION
torchmetrics >=1.0.0 introduces some breaking changes. Need to evaluate.