### PR TITLE
Add class agnostic average precision metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The above metrics are available for Binary, Multiclass, and Multilabel classific
 
 ### Object Detection:
 - `MeanAveragePrecision`: Coco mean average precision (mAP) computation across different classes, under multiple [IoU(s)](https://en.wikipedia.org/wiki/Jaccard_index).
+- `ClassAgnosticAveragePrecision`: Coco mean average prevision (mAP) calculated in a class-agnostic manner. Considers all classes as one class.
 
 ### Image Caption:
   - `BleuScore`: computes the Bleu score. For more details, refer to [BLEU: a Method for Automatic Evaluation of Machine Translation](http://www.aclweb.org/anthology/P02-1040.pdf).

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = visionmetrics
-version = 0.0.11
+version = 0.0.12
 description = Evaluation metric codes for various vision tasks.
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -209,6 +209,21 @@ class TestClassAgnosticAveragePrecision(unittest.TestCase):
         self.assertEqual(result['classes'], -1)
         self.assertEqual(result['map_per_class'], -1)
 
+    def test_two_images(self):
+        PREDICTIONS = [[[0, 1.0, 0, 0, 1, 1],
+                        [1, 1.0, 0.5, 0.5, 1, 1]],
+                       [[2, 1.0, 0.1, 0.1, 0.5, 0.5]]]
+
+        TARGETS = [[[1, 0, 0, 1, 1],
+                    [2, 0.5, 0.5, 1, 1]],
+                   [[1, 0.1, 0.1, 0.5, 0.5]]]
+
+        metric = ClassAgnosticAveragePrecision(iou_thresholds=[0.5])
+        metric.update(PREDICTIONS, TARGETS)
+        result = metric.compute()
+        self.assertEqual(result['map_50'], 1.0)
+        self.assertEqual(result['classes'], -1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -2,10 +2,11 @@ import unittest
 
 import torch
 
-from visionmetrics.detection import MeanAveragePrecision
+from visionmetrics.detection import (ClassAgnosticAveragePrecision,
+                                     MeanAveragePrecision)
 
 
-class TestDetection(unittest.TestCase):
+class TestMeanAveragePrecision(unittest.TestCase):
     def test_perfect_one_image_absolute_coordinates(self):
 
         PREDICTIONS = [[[0, 1.0, 0, 0, 10, 10],
@@ -178,6 +179,35 @@ class TestDetection(unittest.TestCase):
         self.assertAlmostEqual(result['map_small'].item(), 1.0, places=5)
         self.assertAlmostEqual(result['map_medium'].item(), 1.0, places=5)
         self.assertAlmostEqual(result['map_large'].item(), 1.0, places=5)
+
+
+class TestClassAgnosticAveragePrecision(unittest.TestCase):
+    def test_class_agnostic_ap_correct(self):
+        PREDICTIONS = [[[0, 1.0, 0, 0, 1, 1]]]
+        TARGETS = [[[1, 0, 0, 1, 1]]]
+
+        metric = ClassAgnosticAveragePrecision(iou_thresholds=[0.5], class_metrics=False)
+        metric.update(PREDICTIONS, TARGETS)
+        result = metric.compute()
+        self.assertEqual(result['map_50'], 1.0)
+        self.assertEqual(result['classes'], -1)
+        self.assertEqual(result['map_per_class'], -1)
+
+        metric = ClassAgnosticAveragePrecision(iou_thresholds=[0.5], class_metrics=True)
+        metric.update(PREDICTIONS, TARGETS)
+        result = metric.compute()
+        self.assertEqual(result['classes'], -1)
+        self.assertEqual(result['map_per_class'], 1)
+
+    def test_class_agnostic_ap_incorrect(self):
+        PREDICTIONS = [[[0, 1.0, 0, 0, 1, 1]]]
+        TARGETS = [[[1, 0, 0, 0.1, 0.1]]]
+        metric = ClassAgnosticAveragePrecision(iou_thresholds=[0.5])
+        metric.update(PREDICTIONS, TARGETS)
+        result = metric.compute()
+        self.assertEqual(result['map_50'], 0.0)
+        self.assertEqual(result['classes'], -1)
+        self.assertEqual(result['map_per_class'], -1)
 
 
 if __name__ == '__main__':

--- a/visionmetrics/detection/__init__.py
+++ b/visionmetrics/detection/__init__.py
@@ -2,4 +2,5 @@
 
 
 # Import custom metrics from visionmetrics
-from visionmetrics.detection.mean_ap import MeanAveragePrecision
+from visionmetrics.detection.mean_ap import (ClassAgnosticAveragePrecision,
+                                             MeanAveragePrecision)

--- a/visionmetrics/detection/mean_ap.py
+++ b/visionmetrics/detection/mean_ap.py
@@ -73,3 +73,19 @@ class MeanAveragePrecision(detection.mean_ap.MeanAveragePrecision):
             return {'boxes': boxes[:, -4:], 'labels': boxes[:, 0].to(torch.int), 'scores': boxes[:, 1].to(torch.float)}
         else:
             return {'boxes': boxes[:, -4:], 'labels': boxes[:, 0].to(torch.int)}
+
+
+class ClassAgnosticAveragePrecision(MeanAveragePrecision):
+    """
+    Calculates the average precision (AP) for object detection tasks in a class-agnostic manner.
+    It treats all classes as a single class (-1) and evaluates average precision for this class.
+    """
+
+    def update(self, predictions: List[List[List[float]]], targets: List[List[List[float]]]) -> None:
+        predictions, targets = self._make_class_agnostic(predictions), self._make_class_agnostic(targets)
+        return super().update(predictions, targets)
+
+    def _make_class_agnostic(self, preds_or_targets: List[List[List[float]]]) -> List[List[List[float]]]:
+        # Replace the class labels with -1
+        preds_or_targets = [[[-1] + box[1:] for box in boxes_per_img] for boxes_per_img in preds_or_targets]
+        return preds_or_targets


### PR DESCRIPTION
This PR adds a new metric - ClassAgnosticAveragePrecision. It calculate Coco mAP in a class agnostic manner by considering all class labels as -1.