### PR TITLE
Update default AOAI requests_interval and fix includeGrounding logic

### DIFF
--- a/visionmetrics/caption/azure_openai_model_eval.py
+++ b/visionmetrics/caption/azure_openai_model_eval.py
@@ -56,12 +56,13 @@ class AzureOpenAITextModelCategoricalScore(AzureOpenAITextModelCategoricalEvalua
         see https://github.com/microsoft/irisml-tasks-azure-openai/blob/main/irisml/tasks/create_azure_openai_chat_model.py.
     """
     def __init__(self, endpoint: str, deployment_name: str, system_message=DEFAULT_SYSTEM_MESSAGE, prompt_template=DEFAULT_PROMPT_TEMPLATE,
-                 temperature=0.0, max_tokens=50, positive_threshold=0.5, negative_value=''):
+                 temperature=0.0, max_tokens=50, requests_interval=0, positive_threshold=0.5, negative_value=''):
         super().__init__(endpoint=endpoint,
                          deployment_name=deployment_name,
                          system_message=system_message,
                          prompt_template=prompt_template,
                          temperature=temperature,
                          max_tokens=max_tokens,
+                         requests_interval=requests_interval,
                          positive_threshold=positive_threshold,
                          negative_value=negative_value)

--- a/visionmetrics/caption/azure_openai_model_eval_base.py
+++ b/visionmetrics/caption/azure_openai_model_eval_base.py
@@ -47,7 +47,7 @@ class AzureOpenAITextModelCategoricalEvaluatorBase(Metric):
         see https://github.com/microsoft/irisml-tasks-azure-openai/blob/main/irisml/tasks/create_azure_openai_chat_model.py.
     """
     def __init__(self, endpoint: str, deployment_name: str, system_message: str, prompt_template: str,
-                 temperature=0.0, max_tokens=50, requests_interval=30, num_responses=1, positive_threshold=0.5, negative_value=''):
+                 temperature=0.0, max_tokens=50, requests_interval=0, num_responses=1, positive_threshold=0.5, negative_value=''):
         super().__init__()
         if PREDICTION_PLACEHOLDER not in prompt_template or TARGET_PLACEHOLDER not in prompt_template:
             raise ValueError("Both the predicted placeholder {PREDICTION_PLACEHOLDER} and target placeholder {TARGET_PLACEHOLDER} must be present in prompt_template.")

--- a/visionmetrics/key_value_pair/key_value_pair_eval.py
+++ b/visionmetrics/key_value_pair/key_value_pair_eval.py
@@ -146,7 +146,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
         if key_schema["type"] in [JSONSchemaKeyType.String, JSONSchemaKeyType.Number, JSONSchemaKeyType.Integer]:
             if "enum" in key_schema:
                 class_map = self._get_enum_class_map(key_schema["enum"])
-                if "includeGrounding" in key_schema:
+                if "includeGrounding" in key_schema and key_schema["includeGrounding"] == True:
                     self._assign_key_metric_map_values(key=key,
                                                        metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                        metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},
@@ -162,7 +162,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
                                                    metric_args={"error_threshold": 0.0})
         elif key_schema["type"] == JSONSchemaKeyType.Boolean:
             class_map = self._get_enum_class_map([True, False])
-            if "includeGrounding" in key_schema:
+            if "includeGrounding" in key_schema and key_schema["includeGrounding"] == True:
                 self._assign_key_metric_map_values(key=key,
                                                    metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                    metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},
@@ -177,7 +177,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
             if key_schema["items"]["type"] in SIMPLE_KEY_TYPES:
                 if "enum" in key_schema["items"]:
                     class_map = self._get_enum_class_map(key_schema["items"]["enum"])
-                    if "includeGrounding" in key_schema["items"]:
+                    if "includeGrounding" in key_schema["items"] and key_schema["items"]["includeGrounding"] == True:
                         self._assign_key_metric_map_values(key=key,
                                                            metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                            metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},

--- a/visionmetrics/key_value_pair/key_value_pair_eval.py
+++ b/visionmetrics/key_value_pair/key_value_pair_eval.py
@@ -146,7 +146,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
         if key_schema["type"] in [JSONSchemaKeyType.String, JSONSchemaKeyType.Number, JSONSchemaKeyType.Integer]:
             if "enum" in key_schema:
                 class_map = self._get_enum_class_map(key_schema["enum"])
-                if "includeGrounding" in key_schema and key_schema["includeGrounding"] == True:
+                if "includeGrounding" in key_schema and key_schema["includeGrounding"] is True:
                     self._assign_key_metric_map_values(key=key,
                                                        metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                        metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},
@@ -162,7 +162,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
                                                    metric_args={"error_threshold": 0.0})
         elif key_schema["type"] == JSONSchemaKeyType.Boolean:
             class_map = self._get_enum_class_map([True, False])
-            if "includeGrounding" in key_schema and key_schema["includeGrounding"] == True:
+            if "includeGrounding" in key_schema and key_schema["includeGrounding"] is True:
                 self._assign_key_metric_map_values(key=key,
                                                    metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                    metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},
@@ -177,7 +177,7 @@ class KeyValuePairExtractionScore(KeyValuePairEvaluatorBase):
             if key_schema["items"]["type"] in SIMPLE_KEY_TYPES:
                 if "enum" in key_schema["items"]:
                     class_map = self._get_enum_class_map(key_schema["items"]["enum"])
-                    if "includeGrounding" in key_schema["items"] and key_schema["items"]["includeGrounding"] == True:
+                    if "includeGrounding" in key_schema["items"] and key_schema["items"]["includeGrounding"] is True:
                         self._assign_key_metric_map_values(key=key,
                                                            metric_name=SupportedKeyWiseMetric.Detection_MicroPrecisionRecallF1,
                                                            metric_args={"iou_threshold": 0.5, "box_format": "xyxy", "coords": "absolute"},


### PR DESCRIPTION
Updates the default AOAI requests_interval in the AzureOpenAITextModelCategoricalScore to 0 instead of the original 30.
Fixes the bug where includeGrounding's value is not considered (only the presence of the includeGrounding key) to determine whether a key should have a detection metric assigned to it.