### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: read
 
 on:
   release:

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ exclude =
 [options.extras_require] 
 caption = 
     pycocoevalcap
-    pycocotools
+    pycocotools==2.0.8 # 2.0.9 and 2.0.10 miss a default info field which causes issues with unit tests
 dev = 
     pre-commit
     flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ exclude =
 [options.extras_require] 
 caption = 
     pycocoevalcap
-    pycocotools==2.0.8 # 2.0.9 and 2.0.10 miss a default info field which causes issues with unit tests
+    pycocotools==2.0.8  # 2.0.9 and 2.0.10 miss a default info field which causes issues with unit tests
 dev = 
     pre-commit
     flake8


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/visionmetrics/security/code-scanning/2](https://github.com/microsoft/visionmetrics/security/code-scanning/2)

The best way to fix the problem is to explicitly restrict the GITHUB_TOKEN permissions by adding a `permissions` block to the workflow, following the principle of least privilege. In this workflow, the minimum required permission is to allow reading repository contents (e.g., for actions/checkout to read source code). This can be achieved by adding the following at the root level, just below the workflow name and above `on:`: 

```yaml
permissions:
  contents: read
```

This applies the restriction to all jobs unless a job-specific permissions block overrides it. No other permissions are needed for the workflow's steps. Only one region of the file (.github/workflows/release.yml, near the top) needs to be edited to insert this block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
