### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/visionmetrics/security/code-scanning/1](https://github.com/microsoft/visionmetrics/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block with the least privilege necessary. Since this workflow performs only code checkout and runs tests, it does not need any write permissions. The minimum required is `contents: read`, which allows the workflow to read the repository contents during checkout but forbids other write actions. You should add this block at the level of the `test` job in `.github/workflows/test.yml` (line 10), which applies only to this job. You do not need to change any existing functionality, and no other methods, imports, or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
